### PR TITLE
fix(ci): classifier reads steps.<id>.outcome not .conclusion

### DIFF
--- a/.github/workflows/claude-build.yml
+++ b/.github/workflows/claude-build.yml
@@ -107,9 +107,10 @@ jobs:
         if: always()
         run: |
           # The action does NOT set outputs.conclusion reliably (it's almost always
-          # empty), but the step's own conclusion (success/failure/cancelled) is
-          # populated correctly via continue-on-error semantics. Use that instead.
-          STEP_CONCLUSION="${{ steps.claude-build.conclusion }}"
+          # empty). Use the step's own outcome — NOT conclusion — because with
+          # continue-on-error: true the conclusion is always "success" (it reflects
+          # the post-continue-on-error state). outcome reflects the actual result.
+          STEP_CONCLUSION="${{ steps.claude-build.outcome }}"
           ELAPSED=$(( $(date +%s) - ${{ steps.timer.outputs.start }} ))
 
           echo "Step conclusion: $STEP_CONCLUSION"


### PR DESCRIPTION
## Summary

- Single-line fix in `.github/workflows/claude-build.yml`: change `steps.claude-build.conclusion` → `steps.claude-build.outcome`
- With `continue-on-error: true`, `conclusion` is always `success` (it reflects the *post*-continue-on-error state). `outcome` is the pre-swallow result.
- Without this, a failing Claude action (auth 401, rate limit, OOM) leaves the issue stuck in `ready-to-build` with no diagnostic — the cascade stalls silently.

## How it was found

A diamond cascade pipeline test stalled at issue A. Build Feature workflow ran for 1m4s, action exited 401 "Invalid authentication credentials", classifier read `Step conclusion: success` and exited 0 without relabeling. Issue stayed in `ready-to-build` indefinitely; B/C/D never woke up.

## Test plan

- [ ] CI test-suite passes on this PR (also exercises fix #5: required status check on main)
- [ ] After merge: re-run the diamond cascade test from `~/civilian-apps/studio/operations/pipeline-test-runbook.md`
- [ ] On a deliberately-failing build, verify the issue gets relabeled `rate-limited` (if <30s) or `build-failed` (if >30s) instead of staying `ready-to-build`

## Mirror

The same fix needs to land in `civilian-apps/templates/project-template/.github/workflows/claude-build.yml` so future bootstrapped projects don't carry the bug. Already patched locally; will commit separately.