### PR TITLE
fix(ci): install supabase CLI, agent visibility, tighter turn budget

### DIFF
--- a/.github/workflows/claude-build.yml
+++ b/.github/workflows/claude-build.yml
@@ -36,6 +36,14 @@ jobs:
           node-version: '22'
       - run: npm install
 
+      # Install the Supabase CLI binary so the agent can run `supabase start`
+      # and `npm run gen:types` if it touches supabase/migrations/. The CLI
+      # itself is a small download (~30s); `supabase start` is only invoked
+      # by the agent when it actually needs DB types regenerated.
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
       - name: Check dependencies
         run: |
           ISSUE_BODY=$(gh issue view "$ISSUE_NUM" --json body -q '.body')
@@ -68,19 +76,26 @@ jobs:
             - Never create, edit, or delete any file under .github/workflows/ or .github/actions/. The action's token lacks the `workflows` scope; the push will be rejected. If the issue asks for workflow changes, stop and post a comment on the issue explaining you cannot.
             - The PR body MUST start with `Closes #${{ env.ISSUE_NUM }}.` (literal — GitHub uses this to auto-close on merge).
             - Stage explicit paths only with `git add <paths>`. Never `git add -A`. Never include `.github/**` in any commit.
+            - VISIBILITY: Step 0 below (post a starting comment on the issue) is mandatory. Do it before anything else. Without it, the human watching the issue list has zero signal that work has begun.
+            - GEN:TYPES: `npm run gen:types` requires a running local Supabase. If your changes touch `supabase/migrations/**`, FIRST run `supabase start` (takes ~2 min for the initial Docker pull, then fast on subsequent calls) BEFORE running `npm run gen:types`. If your changes do NOT touch `supabase/migrations/**`, you do not need gen:types and you must NOT run `supabase start` — it just wastes time. Never run `gen:types` against a stopped Supabase; it will hang.
 
-            TURN BUDGET DISCIPLINE: You have 90 turns. Aim to push by turn 60. If you reach turn 70 without a pushed branch, STOP iterating and ship what you have:
+            TURN BUDGET DISCIPLINE: You have 60 turns. Aim to push by turn 40. If you reach turn 50 without a pushed branch, STOP iterating and ship what you have:
               - commit current work-in-progress with message prefix `wip: ` if not finished
               - push the branch
               - open the PR with a body that says `Closes #${{ env.ISSUE_NUM }}. WIP — hit turn budget at step X.`
               A WIP PR is recoverable; no PR is a dead build that humans must restart.
 
+            HEARTBEAT: After turn 20 (if you have not yet pushed) post a brief progress comment on the issue with `gh issue comment ${{ env.ISSUE_NUM }} --body "Turn ~20: <one-sentence summary of current state>"`. This is not optional — it is the only way the human watcher knows you are still alive.
+
             Steps (follow in order, use the Bash/Edit/Write tools):
+            0. MANDATORY FIRST ACTION — post a starting comment on the issue so it is visible from the issue page that work has begun:
+                 gh issue comment ${{ env.ISSUE_NUM }} --body "Started building. Branch \`claude/issue-${{ env.ISSUE_NUM }}\` will be pushed and a PR opened when ready."
+               Do this BEFORE step 1. Do not skip.
             1. Read the issue body: gh issue view ${{ env.ISSUE_NUM }} --json title,body
             2. Read CHANGELOG.md (top 30 lines) to see what other recent issues touched — this tells you what shared files (CHANGELOG, tsconfig, jest config, package.json) might conflict.
             3. Fetch the latest default branch so the base is current: git fetch origin main && git checkout -b claude/issue-${{ env.ISSUE_NUM }} origin/main
             4. Follow TDD: write a failing test first, then minimum code to pass, then refactor. Vertical slices.
-            5. Run the FULL test suite, lint, and type check. Fix anything that breaks.
+            5. Run the FULL test suite, lint, and type check. Fix anything that breaks. If your changes touch `supabase/migrations/**`, also run `supabase start && npm run gen:types` exactly once before running tests, so the generated types in `src/libs/supabase/types.ts` reflect the new schema.
             6. Update CHANGELOG.md per rules/changelog-rule.md — append a new dated entry, never overwrite existing entries.
             7. Stage explicit paths and commit with a conventional-commit subject, e.g. `feat: add /terms page`.
             8. Rebase onto latest main in case it moved during your work:
@@ -101,7 +116,7 @@ jobs:
                 $(git log -1 --pretty=%b)" \
                   --head claude/issue-${{ env.ISSUE_NUM }}
             11. Do not stop until the PR is open. Do not ask for confirmation.
-          claude_args: '--max-turns 90 --model claude-opus-4-6 --allowedTools Bash,Read,Write,Edit,Glob,Grep'
+          claude_args: '--max-turns 60 --model claude-opus-4-6 --allowedTools Bash,Read,Write,Edit,Glob,Grep'
 
       - name: Classify result
         if: always()


### PR DESCRIPTION
## Summary

After PR #19 fixed the classifier, a re-run of the cascade test stalled at issue #20 for 36 minutes with **zero observable output** (no commits, no branch, no PR, no issue comments, no log files because GitHub doesn't finalize step logs for cancelled steps). Root cause: the build prompt instructs the agent to run `npm run gen:types` whenever the issue touches a Supabase migration, but that script needs a running local Supabase that the workflow never started. The agent likely got stuck in a loop trying to make the command work.

This PR makes three changes to unblock and one to harden:

1. **Install Supabase CLI** via `supabase/setup-cli@v1` after `npm install`. Adds ~30s. The agent uses it on demand.
2. **Mandatory Step 0** in the build prompt: post a comment "Started building" on the issue. Plus a turn-20 heartbeat rule. Fixes the visibility hole — without this, hung builds are invisible from the issue page.
3. **Conditional gen:types** rule: agent runs `supabase start` only when changes touch `supabase/migrations/**`, and is told never to call `gen:types` against a stopped Supabase.
4. **Tighten turn budget** 90 → 60, push-by-40, WIP-by-50. Faster fail surfaces stuck builds in ~15 min instead of 30.

## Background

- Previous successful builds (e.g. PR #9) worked because the agent hand-edited `src/libs/supabase/types.ts` instead of running `gen:types`. That approach is non-deterministic — relying on the agent to mimic the generator each time was the brittle dependency that broke this run.
- The 36-min hang was confirmed via `gh api jobs/<id>` showing the runner alive but the action step never completing. The action's stdout was never persisted because GitHub only finalizes step logs on completion, not on cancel.

## Test plan

- [ ] CI test-suite passes on this PR (also re-exercises fix #5 from the prior session)
- [ ] After merge: re-run the diamond cascade test
- [ ] On the next build, verify the issue gets a "Started building" comment within 30s of label add
- [ ] On any build that touches `supabase/migrations/**`, verify `supabase start` is called and `gen:types` produces a real diff to `src/libs/supabase/types.ts`

## Mirror

Same change is committed locally to `civilian-apps/templates/project-template/.github/workflows/claude-build.yml` so future bootstrapped projects don't carry the bug.