### PR TITLE
fix(ci): auto-merge agent PRs + silent-on-success review

### DIFF
--- a/.github/workflows/claude-auto-merge.yml
+++ b/.github/workflows/claude-auto-merge.yml
@@ -1,0 +1,32 @@
+name: Auto-merge agent PRs
+on:
+  pull_request:
+    types: [opened, reopened]
+
+# Enables auto-merge on PRs opened from `claude/issue-*` branches by the
+# build agent. Auto-merge waits for required status checks (test-suite)
+# to pass, then squashes and deletes the branch. This closes the merge
+# gap in the autonomous pipeline — without it, agent PRs sit open until
+# a human clicks the green button, breaking the issue → build → close →
+# pacer chain.
+#
+# Why a workflow and not a step in the build prompt: keeps merge policy
+# as code (not as agent-prompt drift), and survives prompt rewrites.
+jobs:
+  enable-auto-merge:
+    if: startsWith(github.event.pull_request.head.ref, 'claude/issue-')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr merge "$PR_NUM" \
+            --repo "${{ github.repository }}" \
+            --auto \
+            --squash \
+            --delete-branch

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -53,6 +53,10 @@ jobs:
             Check: does the code follow rules/app-spec.md and CLAUDE.md?
             The full test suite has already run and passed — focus on
             design, edge cases, and spec adherence.
-            Post your review as PR comments.
-            If everything passes, add the label "ready-for-human-review".
+
+            SILENT-ON-SUCCESS: only post review comments if you find
+            issues that need attention. If everything matches the spec
+            and rules, do NOT post anything — say so in your final
+            response and exit. The test suite is the merge gate; this
+            review is a safety net for spec drift, not a chatty pass.
           claude_args: '--max-turns 15 --model claude-sonnet-4-6 --allowedTools Bash(git*),Read,Glob,Grep'


### PR DESCRIPTION
## Summary

Two changes that close the autonomous-cascade gap and reduce review comment noise.

### 1. NEW workflow `claude-auto-merge.yml`

Triggers on `pull_request: opened/reopened`, filters to PRs from `claude/issue-*` branches, enables auto-merge (squash + delete branch). The merge waits for required status checks (`test-suite`).

**Why this is Bug 4**: every prior "successful" cascade run merged PRs manually. Inspecting `mergedBy` on PRs #9, #13, etc. showed `tomas-kubis` clicked the green button each time. The pipeline was never actually autonomous through the merge step. Discovered when PR #29 (from the visibility fix retest) sat open indefinitely with all checks passing.

### 2. `claude-review.yml` — silent-on-success

Added a `SILENT-ON-SUCCESS` rule to the prompt. The advisory AI review now only posts PR comments if it finds issues that need attention. The test-suite is the merge gate; the review is a safety net for spec drift, not a chatty pass.

Reduces comment volume from 1 review comment per PR to 0 unless something is actually wrong.

## This PR must be merged manually

The new auto-merge workflow doesn't exist on `main` yet — it can only auto-merge subsequent PRs. One-time bootstrap.

## Test plan

- [ ] Merge this PR manually
- [ ] Cleanup PR #29, issues #25-#28, and the `claude/issue-25` branch
- [ ] Re-run the diamond cascade from scratch
- [ ] Verify PR opened by build A has auto-merge enabled within ~30s of PR creation
- [ ] Verify the cascade completes A → B+C parallel → D without any human interaction