### PR TITLE
fix(ci): allow bot-initiated build runs (Bug 7)

### DIFF
--- a/.github/workflows/claude-build.yml
+++ b/.github/workflows/claude-build.yml
@@ -69,6 +69,11 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
+          # Allow workflow_dispatch runs initiated by the pacer
+          # (github-actions[bot]) to execute. Without this the action
+          # aborts with "Workflow initiated by non-human actor" and
+          # the autonomous cascade dies at the first pacer dispatch.
+          allowed_bots: '*'
           prompt: |
             You are implementing GitHub issue #${{ env.ISSUE_NUM }} end-to-end. This is NOT a conversation — you must do the work and open a PR.
 


### PR DESCRIPTION
## Summary

One-line fix: set `allowed_bots: '*'` on the `anthropics/claude-code-action@v1` step in `claude-build.yml`.

The pacer dispatches Build Feature via `gh workflow run`, which makes the run's initiator `github-actions[bot]`. The Claude action rejects bot-initiated runs by default with:

```
Action failed with error: Workflow initiated by non-human actor:
github-actions (type: Bot). Add bot to allowed_bots list or use '*'
to allow all bots.
```

This killed every parallel dispatch from the pacer in ~3 seconds at the installation token step. Initially misdiagnosed as a race condition — the real cause is this bot-exclusion policy. See [pipeline-session-2026-04-06-handoff.md](~/civilian-apps/studio/operations/pipeline-session-2026-04-06-handoff.md) for the full investigation.

The review workflow (`claude-review.yml`) already has `allowed_bots: 'claude'` — the build workflow was just missing the equivalent.

## Not being tested this session

This is the last fix of a ~2h session that found 7 bugs. User budget exhausted. Next session should:
1. Verify this PR merges cleanly
2. Close stale issues #39, #40, #41 (Bug 7 victims) and leave #37, #43 (real bugs) open
3. Create a fresh 4-issue diamond
4. Label A `ready-to-build`, B/C/D `blocked`
5. DO NOT TOUCH ANYTHING for 30-40 min — watch the cascade run end-to-end

Full handoff: [pipeline-session-2026-04-06-handoff.md](~/civilian-apps/studio/operations/pipeline-session-2026-04-06-handoff.md)