### PR TITLE
fix(ci): auto-merge issues:write + serial pacer (Bugs 8 & 9)

### DIFF
--- a/.github/workflows/claude-auto-merge.yml
+++ b/.github/workflows/claude-auto-merge.yml
@@ -19,6 +19,11 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # Bug 8: without `issues: write`, GitHub silently skips the
+      # auto-close of linked issues even though the squash commit
+      # contains `Closes #N`. The merger (github-actions[bot]) needs
+      # explicit authority to close issues.
+      issues: write
     steps:
       - name: Enable auto-merge
         env:

--- a/.github/workflows/pacer.yml
+++ b/.github/workflows/pacer.yml
@@ -142,7 +142,12 @@ jobs:
 
           ACTIVE=$(gh issue list --label "ready-to-build" --state open --json number -q 'length')
 
-          MAX_CONCURRENT=3
+          # Bug 9: parallel agent PRs that touch shared files (CHANGELOG.md,
+          # tsconfig, package-lock) race post-merge — one merges, the other
+          # goes mergeStateStatus=DIRTY. Serialising dispatches to one at a
+          # time eliminates the race entirely. The cascade is marginally
+          # slower (serial instead of parallel) but deterministic.
+          MAX_CONCURRENT=1
           SLOTS=$((MAX_CONCURRENT - ACTIVE))
 
           if [ "$SLOTS" -le 0 ]; then


### PR DESCRIPTION
## Summary

Two one-line fixes that close the remaining gaps from the 2026-04-06 debug session. Full context in [pipeline-session-2026-04-06-handoff.md](../blob/main/../civilian-apps/studio/operations/pipeline-session-2026-04-06-handoff.md).

- **Bug 8** — add `issues: write` to `claude-auto-merge.yml` permissions. The github-actions[bot] merger was silently skipping auto-close of linked issues even though the squash commit preserved `Closes #N`, because its token lacked issue-write authority. Verified against PR #46 which merged but left #39 open.
- **Bug 9** — set pacer `MAX_CONCURRENT=1` (was 3). Parallel agent PRs that touch shared files (CHANGELOG.md, tsconfig, package-lock) race post-merge: first merges cleanly, second goes `DIRTY` and stalls. Serialising dispatches eliminates the collision at the cost of wall-time parallelism. The `for` loop + 30s stagger + watchdog stay for defence-in-depth.

Both fixes are mirrored to `civilian-apps/templates/project-template/.github/workflows/` so new projects inherit them.

## Test plan

- [ ] Auto-merge workflow passes required checks and merges this PR
- [ ] This PR's merge itself doesn't auto-close an issue (no `Closes #N` in body) — so this run does not validate Bug 8; that comes in the fresh-diamond run that follows
- [ ] Next fresh diamond cascade: issue A auto-closes after its PR merges (proves Bug 8 fix)
- [ ] Next fresh diamond cascade: B, C, D dispatch one-at-a-time, no DIRTY merge states (proves Bug 9 fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)