### PR TITLE
fix(ci): explicit issue close on PR merge (Bug 8 real fix)

### DIFF
--- a/.github/workflows/claude-auto-merge.yml
+++ b/.github/workflows/claude-auto-merge.yml
@@ -1,28 +1,33 @@
 name: Auto-merge agent PRs
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, closed]
 
-# Enables auto-merge on PRs opened from `claude/issue-*` branches by the
-# build agent. Auto-merge waits for required status checks (test-suite)
-# to pass, then squashes and deletes the branch. This closes the merge
-# gap in the autonomous pipeline — without it, agent PRs sit open until
-# a human clicks the green button, breaking the issue → build → close →
-# pacer chain.
+# Two jobs:
 #
-# Why a workflow and not a step in the build prompt: keeps merge policy
-# as code (not as agent-prompt drift), and survives prompt rewrites.
+# 1. enable-auto-merge — on PR open/reopen. Enables auto-merge on PRs from
+#    `claude/issue-*` branches so they don't sit open waiting for a human
+#    click. Auto-merge waits for the required `test-suite` check, squashes,
+#    and deletes the branch.
+#
+# 2. close-linked-issues — on PR closed+merged. Parses the merged PR body
+#    for `Closes #N` references and explicitly runs `gh issue close`.
+#    Workaround for Bug 8: GitHub's native auto-close-on-merge silently
+#    no-ops when the merging actor is `github-actions[bot]`, regardless of
+#    workflow permissions. We've verified this on PRs #54, #55, #56 against
+#    main with `issues: write` in the permissions block — the perm is
+#    granted, `closingIssuesReferences` resolves correctly, the squash
+#    commit preserves the keyword, and yet the linked issue stays open.
+#    Same anti-recursion family as GITHUB_TOKEN-no-chain.
 jobs:
   enable-auto-merge:
-    if: startsWith(github.event.pull_request.head.ref, 'claude/issue-')
+    if: >
+      github.event.action != 'closed' &&
+      startsWith(github.event.pull_request.head.ref, 'claude/issue-')
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-      # Bug 8: without `issues: write`, GitHub silently skips the
-      # auto-close of linked issues even though the squash commit
-      # contains `Closes #N`. The merger (github-actions[bot]) needs
-      # explicit authority to close issues.
       issues: write
     steps:
       - name: Enable auto-merge
@@ -35,3 +40,45 @@ jobs:
             --auto \
             --squash \
             --delete-branch
+
+  close-linked-issues:
+    if: >
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Close issues referenced by `Closes #N` / `Fixes #N` / `Resolves #N`
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # GitHub recognises closing keywords: close/closes/closed,
+          # fix/fixes/fixed, resolve/resolves/resolved. Case-insensitive.
+          # We match the same set. Cross-repo refs (`owner/repo#N`) are
+          # intentionally not handled — closing an issue in another repo
+          # from here is a policy call we don't want to make silently.
+          ISSUES=$(echo "$PR_BODY" | grep -oiE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' | grep -oE '#[0-9]+' | sed 's/#//' | sort -u)
+
+          if [ -z "$ISSUES" ]; then
+            echo "No closing keywords found in PR #$PR_NUM body. Nothing to do."
+            exit 0
+          fi
+
+          echo "PR #$PR_NUM references issues: $ISSUES"
+          for N in $ISSUES; do
+            STATE=$(gh issue view "$N" --json state -q '.state' 2>/dev/null || echo "MISSING")
+            if [ "$STATE" = "MISSING" ]; then
+              echo "Issue #$N not found (cross-repo ref or typo) — skipping."
+              continue
+            fi
+            if [ "$STATE" = "CLOSED" ]; then
+              echo "Issue #$N already closed — skipping."
+              continue
+            fi
+            gh issue close "$N" --comment "Auto-closed by PR #$PR_NUM (claude-auto-merge workflow)."
+            echo "Closed issue #$N."
+          done


### PR DESCRIPTION
Closes #58.

## Summary

The previous Bug 8 fix (PR #49) added `issues: write` to `claude-auto-merge.yml`. This was based on the handoff doc's hypothesis that the merger's token lacked authority. **That hypothesis was wrong** — verified live on PRs #54, #55, #56:

- workflow log shows `Issues: write` on GITHUB_TOKEN
- squash commits preserved `Closes #N.` via `squash_merge_commit_message=PR_BODY`
- GraphQL `closingIssuesReferences` resolved correctly
- **and yet every linked issue stayed OPEN after merge**

Revised root cause: GitHub's native auto-close-on-merge silently no-ops when the merging actor is `github-actions[bot]`, regardless of workflow permissions. Same anti-recursion family as `GITHUB_TOKEN`-no-chain.

## Fix

New `close-linked-issues` job in the same workflow file, triggered on `pull_request: closed` when `merged == true`. Parses the PR body for the same closing keywords GitHub recognises (`close[sd]?`, `fix(e[sd])?`, `resolve[sd]?`), deduplicates, and runs `gh issue close`. Already-closed issues and cross-repo references are skipped.

Mirrored to `civilian-apps/templates/project-template/.github/workflows/claude-auto-merge.yml`.

## Self-test

This PR references test issue #58 via `Closes #58.` above. When this PR merges (via github-actions[bot] auto-merge), the NEW close-linked-issues job runs. If #58 auto-closes, the fix is validated end-to-end.

## Bonus finding: Bug 10

Discovered while validating Bug 9: issue #53 (admin tags dashboard) hit `max_turns (60)` in claude-code-action without ever pushing a branch. The WIP-safety-net rule from fix #4 triggers at turn 70, but the turn budget was ALSO tightened to 60 in the same fix, so WIP never fires. Either bump budget to 90 or drop WIP trigger to 50. Not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)