### PR TITLE
fix(ci): bug-8 close-linked-issues — add GH_REPO and tighten regex

### DIFF
--- a/.github/workflows/claude-auto-merge.yml
+++ b/.github/workflows/claude-auto-merge.yml
@@ -53,15 +53,16 @@ jobs:
       - name: Close issues referenced by `Closes #N` / `Fixes #N` / `Resolves #N`
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           PR_NUM: ${{ github.event.pull_request.number }}
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          # GitHub recognises closing keywords: close/closes/closed,
-          # fix/fixes/fixed, resolve/resolves/resolved. Case-insensitive.
-          # We match the same set. Cross-repo refs (`owner/repo#N`) are
-          # intentionally not handled — closing an issue in another repo
-          # from here is a policy call we don't want to make silently.
-          ISSUES=$(echo "$PR_BODY" | grep -oiE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' | grep -oE '#[0-9]+' | sed 's/#//' | sort -u)
+          # Match closing keywords only at the start of a line (after optional
+          # whitespace). This mirrors GitHub's own stricter interpretation and
+          # avoids false positives on prose references like "the fix from #4".
+          # Keywords: close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved.
+          # Cross-repo refs (`owner/repo#N`) are intentionally not handled.
+          ISSUES=$(printf '%s\n' "$PR_BODY" | grep -oiE '^[[:space:]]*(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' | grep -oE '#[0-9]+' | sed 's/#//' | sort -u)
 
           if [ -z "$ISSUES" ]; then
             echo "No closing keywords found in PR #$PR_NUM body. Nothing to do."


### PR DESCRIPTION
## Summary

Two bugs in the close-linked-issues job shipped in PR #57, both revealed by the PR #57 self-test (which was itself masked by GitHub's native auto-close firing under my human identity on PR #57):

1. **Missing `GH_REPO` env** — `gh issue view` had no repo context in the Actions runner (no checkout step), returned empty, and the script's `|| echo MISSING` fallback marked every issue as "not found" and skipped the close call.
2. **Regex too loose** — `\b(close|fix|resolve...)` matched prose like "WIP rule from fix #4" as a closing keyword, picking up #4 as a phantom issue. Anchored to line start now.

The real Bug 8 root cause (confirmed from PR #57 event data): **GitHub's native auto-close-on-merge uses the identity of whoever enabled auto-merge.** When I enable it manually, GitHub closes issues under my identity. When the workflow enables it (on `claude/issue-*` PRs), the merger is `github-actions[bot]`, and GitHub silently no-ops the auto-close. That's why #54/#55/#56 stayed open but #58 closed — I manually enabled auto-merge on #57, masking the test. This PR's job is the real fix for bot-enabled auto-merges.

## Test plan

- [ ] Cannot self-test from THIS PR for the same reason — manual merge fires native auto-close under my identity. After this lands on main, verify by pushing a dummy commit to a `claude/issue-TEST` branch + opening a PR with `Closes #N` in body + letting the auto-merge workflow enable it → bot identity merge → close-linked-issues job should fire → issue should close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)