### PR TITLE
test: bug 8 validation (close-linked-issues under bot auto-merge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,3 +96,10 @@ All notable changes to this project will be documented in this file.
 - Added: Test verifying the page renders the expected heading.
 - Changed: `jest.config.ts` now transforms TSX with `react-jsx` so component tests can render JSX.
 - Files: `src/app/terms/page.tsx`, `src/app/terms/page.test.tsx`, `src/app/layout.tsx`, `jest.config.ts`
+
+## TEST — bug 8 validation via bot-enabled auto-merge (#60)
+
+Single-line dummy CHANGELOG entry to produce a trivial diff for a
+claude/issue-60 branch PR that will be auto-merged by the workflow.
+Validates the close-linked-issues job fires under github-actions[bot]
+merger identity.


### PR DESCRIPTION
Closes #60.

## Summary

Dummy PR on a `claude/issue-60` branch to validate that the close-linked-issues job from PR #57/#59 fires correctly when github-actions[bot] (not a human) is the actor that enabled auto-merge. This is the exact code path Bug 8 broke — the path that PR #57's self-test could not exercise because I manually enabled auto-merge.

## Expected

1. Auto-merge workflow's `enable-auto-merge` job fires (branch starts with `claude/issue-`)
2. github-actions[bot] runs `gh pr merge --auto` → auto-merge enabled under bot identity
3. test-suite passes → PR auto-merges → GitHub's native auto-close does NOT fire (because merger is bot)
4. `pull_request: closed, merged == true` event → close-linked-issues job fires → parses `Closes #60` → runs `gh issue close 60`
5. Issue #60 is CLOSED.

If step 5 happens, Bug 8 is validated for real.