### PR TITLE
fix(ci): bug 8 polling-inside-job + bug 10 turn budget 100

### DIFF
--- a/.github/workflows/claude-auto-merge.yml
+++ b/.github/workflows/claude-auto-merge.yml
@@ -1,85 +1,95 @@
 name: Auto-merge agent PRs
 on:
   pull_request:
-    types: [opened, reopened, closed]
+    types: [opened, reopened]
 
-# Two jobs:
+# Enables auto-merge on PRs opened from `claude/issue-*` branches and,
+# when the merge actually happens, explicitly closes the linked issues
+# from within the SAME long-lived job.
 #
-# 1. enable-auto-merge — on PR open/reopen. Enables auto-merge on PRs from
-#    `claude/issue-*` branches so they don't sit open waiting for a human
-#    click. Auto-merge waits for the required `test-suite` check, squashes,
-#    and deletes the branch.
+# Why polling inside one job instead of two separate jobs on open and
+# close events: GitHub dispatches merge-driven events (pull_request:
+# closed, push:main) under the actor identity of whoever enabled
+# auto-merge. When github-actions[bot] is that actor (which is always
+# the case for claude/issue-* PRs, because the enable call below runs
+# under GITHUB_TOKEN), the resulting events are treated as
+# GITHUB_TOKEN-originated and do NOT trigger any downstream workflow
+# runs — same anti-recursion rule that blocks label-driven chains.
+# The separate close-linked-issues job we tried previously silently
+# never fired. The only reliable workaround is to keep the work
+# inside the originally-triggered workflow run, which is dispatched
+# from the human (or agent) push that opened the PR, not from
+# GITHUB_TOKEN, and therefore IS allowed to run.
 #
-# 2. close-linked-issues — on PR closed+merged. Parses the merged PR body
-#    for `Closes #N` references and explicitly runs `gh issue close`.
-#    Workaround for Bug 8: GitHub's native auto-close-on-merge silently
-#    no-ops when the merging actor is `github-actions[bot]`, regardless of
-#    workflow permissions. We've verified this on PRs #54, #55, #56 against
-#    main with `issues: write` in the permissions block — the perm is
-#    granted, `closingIssuesReferences` resolves correctly, the squash
-#    commit preserves the keyword, and yet the linked issue stays open.
-#    Same anti-recursion family as GITHUB_TOKEN-no-chain.
+# Bug 8 (root cause): GitHub auto-close-on-merge silently no-ops
+# when the merging actor is github-actions[bot] regardless of the
+# workflow's `issues: write` permissions block. The permissions
+# flip the handoff recommended (PR #49) was the wrong fix — it is
+# retained here as harmless defense-in-depth but does nothing on
+# its own. The real fix is the explicit `gh issue close` call in
+# the polling loop below.
 jobs:
   enable-auto-merge:
-    if: >
-      github.event.action != 'closed' &&
-      startsWith(github.event.pull_request.head.ref, 'claude/issue-')
+    if: startsWith(github.event.pull_request.head.ref, 'claude/issue-')
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     permissions:
       contents: write
       pull-requests: write
       issues: write
     steps:
-      - name: Enable auto-merge
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUM: ${{ github.event.pull_request.number }}
-        run: |
-          gh pr merge "$PR_NUM" \
-            --repo "${{ github.repository }}" \
-            --auto \
-            --squash \
-            --delete-branch
-
-  close-linked-issues:
-    if: >
-      github.event.action == 'closed' &&
-      github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: read
-    steps:
-      - name: Close issues referenced by `Closes #N` / `Fixes #N` / `Resolves #N`
+      - name: Enable auto-merge and close linked issues once merged
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR_NUM: ${{ github.event.pull_request.number }}
-          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          # Match closing keywords only at the start of a line (after optional
-          # whitespace). This mirrors GitHub's own stricter interpretation and
-          # avoids false positives on prose references like "the fix from #4".
-          # Keywords: close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved.
-          # Cross-repo refs (`owner/repo#N`) are intentionally not handled.
-          ISSUES=$(printf '%s\n' "$PR_BODY" | grep -oiE '^[[:space:]]*(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' | grep -oE '#[0-9]+' | sed 's/#//' | sort -u)
+          set -eo pipefail
 
-          if [ -z "$ISSUES" ]; then
-            echo "No closing keywords found in PR #$PR_NUM body. Nothing to do."
-            exit 0
-          fi
+          echo "Enabling auto-merge on PR #$PR_NUM"
+          gh pr merge "$PR_NUM" --auto --squash --delete-branch
 
-          echo "PR #$PR_NUM references issues: $ISSUES"
-          for N in $ISSUES; do
-            STATE=$(gh issue view "$N" --json state -q '.state' 2>/dev/null || echo "MISSING")
-            if [ "$STATE" = "MISSING" ]; then
-              echo "Issue #$N not found (cross-repo ref or typo) — skipping."
-              continue
-            fi
-            if [ "$STATE" = "CLOSED" ]; then
-              echo "Issue #$N already closed — skipping."
-              continue
-            fi
-            gh issue close "$N" --comment "Auto-closed by PR #$PR_NUM (claude-auto-merge workflow)."
-            echo "Closed issue #$N."
+          echo "Polling for merge completion (max 20 min, 15s intervals)"
+          for i in $(seq 1 80); do
+            STATE=$(gh pr view "$PR_NUM" --json state -q '.state')
+            case "$STATE" in
+              MERGED)
+                echo "PR #$PR_NUM merged. Parsing body for closing keywords."
+                BODY=$(gh pr view "$PR_NUM" --json body -q '.body')
+                ISSUES=$(printf '%s\n' "$BODY" | grep -oiE '^[[:space:]]*(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' | grep -oE '#[0-9]+' | sed 's/#//' | sort -u)
+                if [ -z "$ISSUES" ]; then
+                  echo "No Closes/Fixes/Resolves references at start of a line in PR body."
+                  exit 0
+                fi
+                echo "PR #$PR_NUM references issues: $ISSUES"
+                for N in $ISSUES; do
+                  ISTATE=$(gh issue view "$N" --json state -q '.state' 2>/dev/null || echo "MISSING")
+                  if [ "$ISTATE" = "CLOSED" ]; then
+                    echo "Issue #$N already closed — skipping."
+                    continue
+                  fi
+                  if [ "$ISTATE" = "MISSING" ]; then
+                    echo "Issue #$N not found (cross-repo or typo) — skipping."
+                    continue
+                  fi
+                  gh issue close "$N" --comment "Auto-closed by PR #$PR_NUM (auto-merge workflow polling loop)."
+                  echo "Closed issue #$N."
+                done
+                exit 0
+                ;;
+              CLOSED)
+                echo "PR #$PR_NUM was closed without merging. Nothing to do."
+                exit 0
+                ;;
+              OPEN)
+                echo "[${i}/80] PR #$PR_NUM still OPEN, sleeping 15s..."
+                sleep 15
+                ;;
+              *)
+                echo "Unexpected PR state: $STATE. Exiting."
+                exit 1
+                ;;
+            esac
           done
+          echo "Timeout: PR #$PR_NUM did not reach MERGED or CLOSED within 20 minutes."
+          exit 1

--- a/.github/workflows/claude-build.yml
+++ b/.github/workflows/claude-build.yml
@@ -84,7 +84,7 @@ jobs:
             - VISIBILITY: Step 0 below (post a starting comment on the issue) is mandatory. Do it before anything else. Without it, the human watching the issue list has zero signal that work has begun.
             - GEN:TYPES: `npm run gen:types` requires a running local Supabase. If your changes touch `supabase/migrations/**`, FIRST run `supabase start` (takes ~2 min for the initial Docker pull, then fast on subsequent calls) BEFORE running `npm run gen:types`. If your changes do NOT touch `supabase/migrations/**`, you do not need gen:types and you must NOT run `supabase start` — it just wastes time. Never run `gen:types` against a stopped Supabase; it will hang.
 
-            TURN BUDGET DISCIPLINE: You have 60 turns. Aim to push by turn 40. If you reach turn 50 without a pushed branch, STOP iterating and ship what you have:
+            TURN BUDGET DISCIPLINE: You have 100 turns. Aim to push by turn 60. If you reach turn 80 without a pushed branch, STOP iterating and ship what you have:
               - commit current work-in-progress with message prefix `wip: ` if not finished
               - push the branch
               - open the PR with a body that says `Closes #${{ env.ISSUE_NUM }}. WIP — hit turn budget at step X.`
@@ -122,7 +122,7 @@ jobs:
                 $(git log -1 --pretty=%b)" \
                   --head claude/issue-${{ env.ISSUE_NUM }}
             11. Do not stop until the PR is open. Do not ask for confirmation.
-          claude_args: '--max-turns 60 --model claude-opus-4-6 --allowedTools Bash,Read,Write,Edit,Glob,Grep'
+          claude_args: '--max-turns 100 --model claude-opus-4-6 --allowedTools Bash,Read,Write,Edit,Glob,Grep'
 
       - name: Classify result
         if: always()


### PR DESCRIPTION
## Summary

Third (and hopefully last) Bug 8 fix attempt. Previous two failed because GitHub dispatches merge events from \`github-actions[bot]\`-enabled auto-merges under GITHUB_TOKEN identity, and those events do NOT trigger any downstream workflows (anti-recursion, same family as label-chain block). Confirmed live on PR #61: **zero** workflows fired on its close, not just my close-linked-issues job.

### Bug 8 — polling-inside-one-job

Replaces the two-job (open + closed) design with a single long-lived job that enables auto-merge, then polls the PR state every 15s for up to 20 min. On MERGED, parses the body for \`Closes/Fixes/Resolves #N\` (line-anchored regex to avoid prose false positives) and runs \`gh issue close\`. The close happens inside the originally-triggered workflow run — dispatched by the human/agent push that opened the PR, not by GITHUB_TOKEN — so anti-recursion doesn't block it.

Latency: ~15s polling × 1-2 iterations + ~30s test-suite overhead ≈ well under 1 min after merge.

### Bug 10 — turn budget 60 → 100

Issue #53 (admin dashboard) hit \`max_turns (60)\` without pushing. Handoff notes the agent can't reliably count turns, so the prompt's "ship WIP at turn 50" rule is best-effort; the larger budget gives complex features more headroom. Prompt rule realigned to aim for 60, ship WIP at 80.

### Mirrored

Both fixes mirrored to \`civilian-apps/templates/project-template/.github/workflows/\`.

## Test plan

- [ ] Merge this PR (I'll manually enable auto-merge — human-merged means GitHub native auto-close fires, which is fine)
- [ ] After merge, create a small test issue ("add /about page with text + link from home")
- [ ] Label ready-to-build, hands-off
- [ ] Verify: build runs under 100 turns, PR opens, auto-merge workflow polls, issue auto-closes within ~45s of merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)