### PR TITLE
fix(ci): add mode:hitl branch to auto-merge workflow

### DIFF
--- a/.github/workflows/claude-auto-merge.yml
+++ b/.github/workflows/claude-auto-merge.yml
@@ -3,31 +3,34 @@ on:
   pull_request:
     types: [opened, reopened]
 
-# Enables auto-merge on PRs opened from `claude/issue-*` branches and,
-# when the merge actually happens, explicitly closes the linked issues
-# from within the SAME long-lived job.
+# Two modes, selected by label on the linked issue:
 #
-# Why polling inside one job instead of two separate jobs on open and
-# close events: GitHub dispatches merge-driven events (pull_request:
-# closed, push:main) under the actor identity of whoever enabled
-# auto-merge. When github-actions[bot] is that actor (which is always
-# the case for claude/issue-* PRs, because the enable call below runs
-# under GITHUB_TOKEN), the resulting events are treated as
-# GITHUB_TOKEN-originated and do NOT trigger any downstream workflow
-# runs — same anti-recursion rule that blocks label-driven chains.
-# The separate close-linked-issues job we tried previously silently
-# never fired. The only reliable workaround is to keep the work
-# inside the originally-triggered workflow run, which is dispatched
-# from the human (or agent) push that opened the PR, not from
-# GITHUB_TOKEN, and therefore IS allowed to run.
+#   - DEFAULT (autonomous): no special label required. Auto-merge
+#     is enabled, the polling loop waits for the squash merge, then
+#     explicitly closes the linked issue (bug 8 workaround — GitHub
+#     native auto-close silently no-ops under github-actions[bot]
+#     merger identity).
 #
-# Bug 8 (root cause): GitHub auto-close-on-merge silently no-ops
-# when the merging actor is github-actions[bot] regardless of the
-# workflow's `issues: write` permissions block. The permissions
-# flip the handoff recommended (PR #49) was the wrong fix — it is
-# retained here as harmless defense-in-depth but does nothing on
-# its own. The real fix is the explicit `gh issue close` call in
-# the polling loop below.
+#   - `mode:hitl` (human-in-the-loop): added by tech-lead during
+#     implementation-plan building when a feature needs human review
+#     before merging. The job exits early, so auto-merge is NOT
+#     enabled and the PR sits with `ready-for-human-review` until a
+#     human clicks merge. When the human merges, GitHub's native
+#     auto-close fires (because the merger has issue-write authority
+#     as a real user), so the issue closes correctly. No polling
+#     needed on that path.
+#
+# In both modes the issue closes when the PR merges, just via
+# different mechanisms. The human's role in HITL mode is the code
+# review, not issue state management.
+#
+# Why polling inside one job for the autonomous path: merge-driven
+# events from github-actions[bot] auto-merges (pull_request.closed,
+# push:main) are dispatched under GITHUB_TOKEN identity and do NOT
+# trigger any downstream workflow runs (same anti-recursion rule as
+# label chains). A separate close-linked-issues job keyed on the
+# closed event silently never fires. The only reliable workaround
+# is to keep the close call inside the originally-triggered run.
 jobs:
   enable-auto-merge:
     if: startsWith(github.event.pull_request.head.ref, 'claude/issue-')
@@ -38,7 +41,37 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - name: Enable auto-merge and close linked issues once merged
+      - name: Resolve linked issue and check mode
+        id: mode
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -eo pipefail
+
+          # Parse the first Closes/Fixes/Resolves #N line from the PR body.
+          LINKED=$(printf '%s\n' "$PR_BODY" | grep -oiE '^[[:space:]]*(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' | grep -oE '#[0-9]+' | sed 's/#//' | head -1)
+
+          if [ -z "$LINKED" ]; then
+            echo "PR body has no linked issue. Defaulting to autonomous mode."
+            echo "linked=" >> "$GITHUB_OUTPUT"
+            echo "hitl=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "linked=$LINKED" >> "$GITHUB_OUTPUT"
+
+          if gh issue view "$LINKED" --json labels -q '.labels[].name' 2>/dev/null | grep -qx "mode:hitl"; then
+            echo "Issue #$LINKED is labeled mode:hitl — skipping auto-merge. PR will wait for human review and manual merge."
+            echo "hitl=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Issue #$LINKED is autonomous (default). Proceeding with auto-merge + polling."
+            echo "hitl=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Enable auto-merge and close linked issue once merged
+        if: steps.mode.outputs.hitl != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -72,6 +105,10 @@ jobs:
                     echo "Issue #$N not found (cross-repo or typo) — skipping."
                     continue
                   fi
+                  # Strip the classifier's `ready-for-human-review` label before
+                  # closing — in autonomous mode it is a transient signal, not a
+                  # durable one, and we do not want closed issues carrying it.
+                  gh issue edit "$N" --remove-label ready-for-human-review 2>/dev/null || true
                   gh issue close "$N" --comment "Auto-closed by PR #$PR_NUM (auto-merge workflow polling loop)."
                   echo "Closed issue #$N."
                 done


### PR DESCRIPTION
## Summary

Adds a second path to the auto-merge workflow so agent PRs can ship either fully autonomously or with human-in-the-loop review.

- **Autonomous (default, no label):** existing behaviour — workflow enables auto-merge, polling loop waits for the squash merge, explicitly closes the linked issue (bug 8 workaround).
- **`mode:hitl` (label on linked issue):** workflow exits before enabling auto-merge. PR sits with \`ready-for-human-review\`. Human clicks merge → native GitHub auto-close fires under human merger identity → issue closes. No polling needed on this path.

In both modes the issue closes when the PR merges, just via different mechanisms. The human's role in HITL mode is code review, not issue state management.

Also strips the transient \`ready-for-human-review\` label before closing in autonomous mode — closed issues should not carry it.

## Test plan

- [ ] Merge this PR (autonomous path is already validated; this is a fast check that nothing regressed).
- [ ] Create label \`mode:hitl\` (already done in test-project-2).
- [ ] Create a small test issue, label it BOTH \`feature\` and \`mode:hitl\`, label \`ready-to-build\`.
- [ ] Verify: build runs, PR opens, but auto-merge is NOT enabled and PR sits waiting.
- [ ] Manually click merge on the HITL test PR. Verify issue auto-closes via GitHub native auto-close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)